### PR TITLE
Fix typo in story evaluator agent name

### DIFF
--- a/backend/src/agents/story_agent.py
+++ b/backend/src/agents/story_agent.py
@@ -23,7 +23,7 @@ class StoryAgent:
             ),
         )
         self.evaluator = Agent[None](
-            name="Story Evalutator Agent",
+            name="Story Evaluator Agent",
             model="o3-mini",
             instructions=(
                 "You evaluate a story outline and decide if it's good enough. "


### PR DESCRIPTION
## Summary
- fix a typo in the story agent name

## Testing
- `python -m py_compile backend/src/agents/story_agent.py`


------
https://chatgpt.com/codex/tasks/task_e_68485eb366bc8325aaf3bcc567a0f191