### PR TITLE
Fix image generate endpoint

### DIFF
--- a/backend/src/routes/image_routes.py
+++ b/backend/src/routes/image_routes.py
@@ -14,15 +14,11 @@ class RegenerateImageRequest(BaseModel):
 
 @router.post("/generate-image")
 async def generate_image(request: ImageRequest):
-
-    data = request.json
-    image_id = data.get('image_id')
-    new_prompt = data.get('new_prompt')
-    if not image_id or not new_prompt:
-        return HTTPException({'error': 'Image ID and new prompt are required'}), 400
+    if not request.prompt:
+        raise HTTPException(status_code=400, detail="Prompt is required.")
 
     try:
-        new_image_url = image_agent.regenerate_image(image_id, new_prompt)
-        return HTTPException({'new_image_url': new_image_url}), 200
+        image_url = image_agent.generate_image(request.prompt)
+        return {"image_url": image_url}
     except Exception as e:
-        return HTTPException({'error': str(e)}), 500
+        raise HTTPException(status_code=500, detail=str(e))


### PR DESCRIPTION
## Summary
- simplify `/generate-image` route
- use `ImageRequest` model fields directly
- return proper FastAPI responses and raise exceptions on error

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68485ebc10ec8325a4f959fa95512ccd