### PR TITLE
Fix docstring for script alignment agent

### DIFF
--- a/backend/src/agents/script_alignment_agent.py
+++ b/backend/src/agents/script_alignment_agent.py
@@ -4,11 +4,11 @@ class ScriptAlignmentAgent:
 
     def align_script_with_images(self, images, script):
         """
-        Aligns the provided script with the given images.
+        Aligns a list of script dialogue lines with the given images.
         
         Parameters:
         - images: List of image paths or URLs.
-        - script: The script text to be aligned.
+        - script: List of dialogue strings to be aligned.
 
         Returns:
         - aligned_script: A structured representation of the script aligned with images.


### PR DESCRIPTION
## Summary
- clarify that `script` should be a list of dialogue strings in the ScriptAlignmentAgent docstring

## Testing
- `python -m py_compile backend/src/agents/script_alignment_agent.py`

------
https://chatgpt.com/codex/tasks/task_e_68485ebeda7c832591e2bd3dab46cb8c