### PR TITLE
Implement update_script for ScriptAlignmentAgent

### DIFF
--- a/backend/src/agents/script_alignment_agent.py
+++ b/backend/src/agents/script_alignment_agent.py
@@ -1,11 +1,11 @@
 class ScriptAlignmentAgent:
     def __init__(self):
-        pass
+        self.script: list[str] = []
 
     def align_script_with_images(self, images, script):
         """
         Aligns a list of script dialogue lines with the given images.
-        
+
         Parameters:
         - images: List of image paths or URLs.
         - script: List of dialogue strings to be aligned.
@@ -15,10 +15,9 @@ class ScriptAlignmentAgent:
         """
         aligned_script = []
         for i, image in enumerate(images):
-            aligned_script.append({
-                'image': image,
-                'dialogue': script[i] if i < len(script) else ''
-            })
+            aligned_script.append(
+                {"image": image, "dialogue": script[i] if i < len(script) else ""}
+            )
         return aligned_script
 
     def adjust_dialogue(self, aligned_script, index, new_dialogue):
@@ -34,7 +33,7 @@ class ScriptAlignmentAgent:
         - updated_script: The updated aligned script with the modified dialogue.
         """
         if 0 <= index < len(aligned_script):
-            aligned_script[index]['dialogue'] = new_dialogue
+            aligned_script[index]["dialogue"] = new_dialogue
         return aligned_script
 
     def generate_script_summary(self, aligned_script):
@@ -51,3 +50,8 @@ class ScriptAlignmentAgent:
         for item in aligned_script:
             summary += f"Image: {item['image']}, Dialogue: {item['dialogue']}\n"
         return summary.strip()
+
+    def update_script(self, new_script):
+        """Replace the stored script and return the updated version."""
+        self.script = list(new_script)
+        return self.script

--- a/tests/test_script_alignment_agent.py
+++ b/tests/test_script_alignment_agent.py
@@ -1,21 +1,31 @@
 import pytest
 from backend.src.agents.script_alignment_agent import ScriptAlignmentAgent
 
+
 @pytest.fixture
 def agent():
     return ScriptAlignmentAgent()
+
 
 def test_align_script_with_images_handles_mismatched_lengths(agent):
     images = ["img1.png", "img2.png", "img3.png"]
     script = ["Hello", "World"]
     result = agent.align_script_with_images(images, script)
     assert len(result) == len(images)
-    assert result[0]['image'] == "img1.png" and result[0]['dialogue'] == "Hello"
-    assert result[1]['image'] == "img2.png" and result[1]['dialogue'] == "World"
-    assert result[2]['image'] == "img3.png" and result[2]['dialogue'] == ""
+    assert result[0]["image"] == "img1.png" and result[0]["dialogue"] == "Hello"
+    assert result[1]["image"] == "img2.png" and result[1]["dialogue"] == "World"
+    assert result[2]["image"] == "img3.png" and result[2]["dialogue"] == ""
+
 
 def test_adjust_dialogue_updates_dialogue(agent):
     aligned = agent.align_script_with_images(["img1", "img2"], ["line1", "line2"])
     updated = agent.adjust_dialogue(aligned, 1, "new line")
-    assert updated[1]['dialogue'] == "new line"
-    assert updated[0]['dialogue'] == "line1"
+    assert updated[1]["dialogue"] == "new line"
+    assert updated[0]["dialogue"] == "line1"
+
+
+def test_update_script(agent):
+    new_script = ["a", "b"]
+    updated = agent.update_script(new_script)
+    assert agent.script == new_script
+    assert updated == new_script


### PR DESCRIPTION
## Summary
- implement `update_script` in `ScriptAlignmentAgent`
- add test for the new method

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `black --check backend/src` *(fails: many files would be reformatted)*
- `cd frontend && npx tsc --noEmit && npx prettier -c src && cd ..` *(fails: many TypeScript errors and style issues)*
- `pytest -q tests/test_script_alignment_agent.py::test_update_script`

------
https://chatgpt.com/codex/tasks/task_e_684861e312f083259cc39a49f8f8d12d