### PR TITLE
Add Whisper-based STT implementation and tests

### DIFF
--- a/backend/src/audio_processing/stt.py
+++ b/backend/src/audio_processing/stt.py
@@ -12,8 +12,22 @@ class STTProcessor:
         Returns:
         str: Transcribed text from the audio.
         """
-        # Implement the transcription logic using OpenAI Whisper
-        pass
+        import os
+        import openai
+        from openai import OpenAIError
+
+        if not os.path.isfile(audio_file):
+            raise FileNotFoundError(f"Audio file '{audio_file}' not found")
+
+        try:
+            with open(audio_file, "rb") as f:
+                result = openai.Audio.transcribe(self.model, f)
+        except OpenAIError as exc:
+            raise RuntimeError(f"OpenAI API error: {exc}") from exc
+        except Exception as exc:
+            raise RuntimeError(f"Failed to transcribe audio: {exc}") from exc
+
+        return result.get("text", "") if isinstance(result, dict) else str(result)
 
     def set_model(self, model):
         """

--- a/tests/test_stt_processor.py
+++ b/tests/test_stt_processor.py
@@ -1,4 +1,6 @@
 from backend.src.audio_processing.stt import STTProcessor
+import openai
+import pytest
 
 
 def test_get_and_set_model():
@@ -6,3 +8,24 @@ def test_get_and_set_model():
     assert stt.get_model() == "model1"
     stt.set_model("model2")
     assert stt.get_model() == "model2"
+
+
+def test_transcribe_audio_returns_text(monkeypatch, tmp_path):
+    audio_path = tmp_path / "clip.mp3"
+    audio_path.write_bytes(b"data")
+
+    def mock_transcribe(model, file, **kwargs):
+        assert model == "whisper-1"
+        file.read()  # ensure file object is usable
+        return {"text": "hello world"}
+
+    monkeypatch.setattr(openai.Audio, "transcribe", mock_transcribe)
+    stt = STTProcessor(model="whisper-1")
+    text = stt.transcribe_audio(str(audio_path))
+    assert text == "hello world"
+
+
+def test_transcribe_audio_missing_file():
+    stt = STTProcessor(model="whisper-1")
+    with pytest.raises(FileNotFoundError):
+        stt.transcribe_audio("nonexistent.mp3")


### PR DESCRIPTION
## Summary
- implement `transcribe_audio` in `STTProcessor` using `openai.Audio.transcribe`
- add tests that mock Whisper API responses

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `black --check backend/src` *(fails: would reformat 20 files)*
- `cd frontend && npx tsc --noEmit && npx prettier -c src && cd ..` *(fails with TypeScript errors)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684861e238e083259c079e8e918ef4b7