### PR TITLE
Add generate_audio_clip test

### DIFF
--- a/backend/src/agents/video_assembly_agent.py
+++ b/backend/src/agents/video_assembly_agent.py
@@ -4,6 +4,7 @@ from moviepy.audio.io.AudioFileClip import AudioFileClip
 from moviepy.video.VideoClip import ImageClip
 from moviepy.video.compositing.CompositeVideoClip import concatenate_videoclips
 
+
 class VideoAssemblyAgent:
     def __init__(self, fps: int = 24):
         self.fps = fps

--- a/tests/test_tts_agent.py
+++ b/tests/test_tts_agent.py
@@ -34,3 +34,13 @@ def test_adjust_audio_properties_modifies_clip():
     faster = agent.adjust_audio_properties(clip, {"speed": 2.0})
     assert len(faster) < len(clip)
 
+
+def test_generate_audio_clip_uses_processor():
+    processor = MagicMock(spec=TTSProcessor)
+    processor.generate_audio.return_value = "result"
+    agent = TTSAgent(processor)
+
+    clip = agent.generate_audio_clip("hi")
+
+    processor.generate_audio.assert_called_once_with("hi")
+    assert clip == "result"


### PR DESCRIPTION
## Summary
- add a unit test for `TTSAgent.generate_audio_clip`
- format backend video assembly agent per Black guidelines

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `black --check backend/src`
- `cd frontend && npx tsc --noEmit && npx prettier -c src && cd ..` *(fails: Cannot find module 'react' typings)*

------
https://chatgpt.com/codex/tasks/task_e_684879282d8c8325a6e18964b0d04de9