### PR TITLE
Add script summary test

### DIFF
--- a/backend/src/agents/video_assembly_agent.py
+++ b/backend/src/agents/video_assembly_agent.py
@@ -4,6 +4,7 @@ from moviepy.audio.io.AudioFileClip import AudioFileClip
 from moviepy.video.VideoClip import ImageClip
 from moviepy.video.compositing.CompositeVideoClip import concatenate_videoclips
 
+
 class VideoAssemblyAgent:
     def __init__(self, fps: int = 24):
         self.fps = fps

--- a/tests/test_script_alignment_agent.py
+++ b/tests/test_script_alignment_agent.py
@@ -29,3 +29,13 @@ def test_update_script(agent):
     updated = agent.update_script(new_script)
     assert agent.script == new_script
     assert updated == new_script
+
+
+def test_generate_script_summary_includes_all_entries(agent):
+    aligned = [
+        {"image": "img1.png", "dialogue": "Hello"},
+        {"image": "img2.png", "dialogue": "World"},
+    ]
+    summary = agent.generate_script_summary(aligned)
+    assert "Image: img1.png, Dialogue: Hello" in summary
+    assert "Image: img2.png, Dialogue: World" in summary


### PR DESCRIPTION
## Summary
- ensure `ScriptAlignmentAgent` summary output lists image/dialogue pairs
- format video assembly agent with black

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `black --check backend/src`
- `pytest -q`
- `npx tsc --noEmit` *(fails: Cannot find module 'react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68487926e7c08325bbf50cc24d5ed93a