### PR TITLE
Implement image editing API endpoints

### DIFF
--- a/backend/src/agents/video_assembly_agent.py
+++ b/backend/src/agents/video_assembly_agent.py
@@ -4,6 +4,7 @@ from moviepy.audio.io.AudioFileClip import AudioFileClip
 from moviepy.video.VideoClip import ImageClip
 from moviepy.video.compositing.CompositeVideoClip import concatenate_videoclips
 
+
 class VideoAssemblyAgent:
     def __init__(self, fps: int = 24):
         self.fps = fps

--- a/backend/src/routes/image_routes.py
+++ b/backend/src/routes/image_routes.py
@@ -10,9 +10,13 @@ class ImageRequest(BaseModel):
     prompt: str
 
 
-class RegenerateImageRequest(BaseModel):
-    image_id: str
+class ModifyImageRequest(BaseModel):
+    image_path: str
     new_prompt: str
+
+
+class RegenerateImageRequest(BaseModel):
+    image_path: str
 
 
 @router.post("/generate-image")
@@ -22,6 +26,32 @@ async def generate_image(request: ImageRequest):
 
     try:
         image_url = image_agent.generate_image(request.prompt)
+        return {"image_url": image_url}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.put("/modify-image")
+async def modify_image(request: ModifyImageRequest):
+    if not request.image_path or not request.new_prompt:
+        raise HTTPException(
+            status_code=400, detail="Image path and new prompt are required."
+        )
+
+    try:
+        image_url = image_agent.modify_image(request.image_path, request.new_prompt)
+        return {"image_url": image_url}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.post("/regenerate-image")
+async def regenerate_image(request: RegenerateImageRequest):
+    if not request.image_path:
+        raise HTTPException(status_code=400, detail="Image path is required.")
+
+    try:
+        image_url = image_agent.regenerate_image(request.image_path)
         return {"image_url": image_url}
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -72,6 +72,33 @@ def test_generate_image_route():
         mock_img.assert_called_once_with("cat")
 
 
+def test_modify_image_route():
+    with patch.object(
+        image_routes.image_agent,
+        "modify_image",
+        return_value="http://edited",
+    ) as mock_mod:
+        payload = {"image_path": "path.png", "new_prompt": "dog"}
+        response = client.put("/images/modify-image", json=payload)
+        assert response.status_code == 200
+        assert response.json() == {"image_url": "http://edited"}
+        mock_mod.assert_called_once_with("path.png", "dog")
+
+
+def test_regenerate_image_route():
+    with patch.object(
+        image_routes.image_agent,
+        "regenerate_image",
+        return_value="http://var",
+    ) as mock_reg:
+        response = client.post(
+            "/images/regenerate-image", json={"image_path": "old.png"}
+        )
+        assert response.status_code == 200
+        assert response.json() == {"image_url": "http://var"}
+        mock_reg.assert_called_once_with("old.png")
+
+
 def test_generate_audio_route():
     with patch.object(
         tts_routes.tts_agent,


### PR DESCRIPTION
## Summary
- add modify-image and regenerate-image FastAPI routes
- create tests for the new image routes
- format backend with black

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `black backend/src --check`
- `cd frontend && npx tsc --noEmit && npx prettier -c src && cd ..` *(fails: missing dependencies)*
- `pytest -q` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6848793cc9048325ae2c6f1010571978