### PR TITLE
Fix assemble_video route parameters

### DIFF
--- a/backend/src/agents/video_assembly_agent.py
+++ b/backend/src/agents/video_assembly_agent.py
@@ -4,6 +4,7 @@ from moviepy.audio.io.AudioFileClip import AudioFileClip
 from moviepy.video.VideoClip import ImageClip
 from moviepy.video.compositing.CompositeVideoClip import concatenate_videoclips
 
+
 class VideoAssemblyAgent:
     def __init__(self, fps: int = 24):
         self.fps = fps

--- a/backend/src/routes/video_routes.py
+++ b/backend/src/routes/video_routes.py
@@ -8,7 +8,8 @@ video_agent = VideoAssemblyAgent()
 
 class AssembleVideoRequest(BaseModel):
     images: list[str]
-    audio: str
+    audio_clips: list[str]
+    output_path: str
 
 
 class PreviewVideoRequest(BaseModel):
@@ -17,10 +18,15 @@ class PreviewVideoRequest(BaseModel):
 
 @router.post("/assemble_video")
 async def assemble_video(request: AssembleVideoRequest):
-    if not request.images or not request.audio:
-        raise HTTPException(status_code=400, detail="Images and audio are required.")
+    if not request.images or not request.audio_clips or not request.output_path:
+        raise HTTPException(
+            status_code=400,
+            detail="Images, audio clips, and output path are required.",
+        )
 
-    video_path = video_agent.assemble_video(request.images, request.audio)
+    video_path = video_agent.assemble_video(
+        request.images, request.audio_clips, request.output_path
+    )
     return {"video_path": video_path}
 
 

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -97,16 +97,21 @@ def test_assemble_video_route():
         "assemble_video",
         return_value="/tmp/out.mp4",
     ) as mock_video:
-        payload = {"images": ["i"], "audio": "a"}
+        payload = {
+            "images": ["i"],
+            "audio_clips": ["a"],
+            "output_path": "out.mp4",
+        }
         response = client.post("/videos/assemble_video", json=payload)
         assert response.status_code == 200
         assert response.json() == {"video_path": "/tmp/out.mp4"}
-        mock_video.assert_called_once_with(["i"], "a")
+        mock_video.assert_called_once_with(["i"], ["a"], "out.mp4")
 
 
 def test_preview_video_route():
     payload = {"video_path": "demo.mp4"}
     response = client.post("/videos/preview_video", json=payload)
     assert response.status_code == 200
-    assert response.json() == {"preview_url": {"message": "Preview generated", "video_path": "demo.mp4"}}
-
+    assert response.json() == {
+        "preview_url": {"message": "Preview generated", "video_path": "demo.mp4"}
+    }


### PR DESCRIPTION
## Summary
- update `AssembleVideoRequest` schema to include `audio_clips` and `output_path`
- pass all parameters through to `VideoAssemblyAgent`
- adjust unit test for new route signature

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `black --check backend/src`
- `cd frontend && npx tsc --noEmit` *(fails: Cannot find module 'react', etc.)*
- `npx prettier -c src`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'agents')*

------
https://chatgpt.com/codex/tasks/task_e_6848793d55208325be3aab8ad7070462