### PR TITLE
Add OpenAI error test

### DIFF
--- a/backend/src/agents/video_assembly_agent.py
+++ b/backend/src/agents/video_assembly_agent.py
@@ -4,6 +4,7 @@ from moviepy.audio.io.AudioFileClip import AudioFileClip
 from moviepy.video.VideoClip import ImageClip
 from moviepy.video.compositing.CompositeVideoClip import concatenate_videoclips
 
+
 class VideoAssemblyAgent:
     def __init__(self, fps: int = 24):
         self.fps = fps


### PR DESCRIPTION
## Summary
- add a regression test for STTProcessor when OpenAI fails
- format `video_assembly_agent` to satisfy `black --check`

## Testing
- `python -m py_compile $(git ls_files '*.py')`
- `black --check backend/src tests/test_stt_processor.py`
- `npx tsc --noEmit` *(fails: Cannot find module 'react')*
- `npx prettier -c src`

------
https://chatgpt.com/codex/tasks/task_e_6848793f43a083259b12c93b8e26280c