### PR TITLE
Add story agent async tests

### DIFF
--- a/backend/src/agents/video_assembly_agent.py
+++ b/backend/src/agents/video_assembly_agent.py
@@ -4,6 +4,7 @@ from moviepy.audio.io.AudioFileClip import AudioFileClip
 from moviepy.video.VideoClip import ImageClip
 from moviepy.video.compositing.CompositeVideoClip import concatenate_videoclips
 
+
 class VideoAssemblyAgent:
     def __init__(self, fps: int = 24):
         self.fps = fps

--- a/tests/test_story_agent.py
+++ b/tests/test_story_agent.py
@@ -1,0 +1,60 @@
+import pytest
+from backend.src.agents import story_agent
+from backend.src.agents.story_agent import StoryAgent, EvaluationFeedback
+
+class DummyResult:
+    def __init__(self, input_items, new_items=None, final_output=None):
+        self.input = input_items
+        self.new_items = new_items or []
+        self.final_output = final_output
+
+    def to_input_list(self):
+        return self.input + self.new_items
+
+
+@pytest.mark.asyncio
+async def test_generate_outline_single_turn(monkeypatch):
+    agent = StoryAgent()
+
+    async def mock_run(starting_agent, input_items, **kwargs):
+        if starting_agent is agent.story_outline_generator:
+            return DummyResult(input_items, ["outline"], None)
+        return DummyResult(input_items, [], EvaluationFeedback(score="pass", feedback="good"))
+
+    monkeypatch.setattr(story_agent.Runner, "run", mock_run)
+    monkeypatch.setattr(story_agent.ItemHelpers, "text_message_outputs", lambda items: "".join(items))
+
+    outline = await agent.generate_outline("idea", max_turns=1)
+    assert outline == "outline"
+
+
+@pytest.mark.asyncio
+async def test_generate_outline_max_turns_exceeded(monkeypatch):
+    agent = StoryAgent()
+    call = {"n": 0}
+
+    async def mock_run(starting_agent, input_items, **kwargs):
+        if starting_agent is agent.story_outline_generator:
+            call["n"] += 1
+            return DummyResult(input_items, [f"outline{call['n']}"])
+        return DummyResult(input_items, [], EvaluationFeedback(score="needs_improvement", feedback="no"))
+
+    monkeypatch.setattr(story_agent.Runner, "run", mock_run)
+    monkeypatch.setattr(story_agent.ItemHelpers, "text_message_outputs", lambda items: "".join(items))
+
+    outline = await agent.generate_outline("idea", max_turns=1)
+    assert outline == "outline2"
+
+
+@pytest.mark.asyncio
+async def test_refine_outline_returns_new(monkeypatch):
+    agent = StoryAgent()
+
+    async def mock_run(starting_agent, input_items, **kwargs):
+        return DummyResult(input_items, ["new outline"])
+
+    monkeypatch.setattr(story_agent.Runner, "run", mock_run)
+    monkeypatch.setattr(story_agent.ItemHelpers, "text_message_outputs", lambda items: "".join(items))
+
+    result = await agent.refine_outline("old", "feedback")
+    assert result == "new outline"


### PR DESCRIPTION
## Summary
- add async tests for StoryAgent
- keep video assembly agent formatted by black

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `black --check backend/src`
- `cd frontend && npx tsc --noEmit && npx prettier -c src && cd ..` *(fails: cannot find React types)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848792fed10832587263282374bfc0f