### PR TITLE
Enable demo mode for integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,26 @@
 # TaleCraft
 An interactive, agentic web app powered by OpenAI to create AI-driven storyboards and short videos, enabling easy, user-driven storytelling.
+
+## Integration Testing
+
+To experiment with the complete stack locally, you can run the backend in
+`DEMO_MODE`. This bypasses all OpenAI endpoints and serves a small frontend build
+mounted at the FastAPI root path.
+
+Steps:
+
+1. Build the frontend:
+
+   ```bash
+   cd frontend && npm install && npm run build
+   mv dist ../frontend_dist
+   ```
+
+2. Start the backend with demo mode enabled:
+
+   ```bash
+   DEMO_MODE=true python backend/src/app.py
+   ```
+
+Visit `http://localhost:8000` in your browser to see the demo interface. API
+routes will return default data suitable for manual testing.

--- a/backend/README.md
+++ b/backend/README.md
@@ -46,6 +46,12 @@ shortvideo-story-creator-backend
    python src/app.py
    ```
 
+### Demo mode
+
+Set the environment variable `DEMO_MODE=true` to bypass external OpenAI calls.
+Default images and transcription text will be returned instead, making it easy
+to test the full stack offline.
+
 ## Usage Guidelines
 
 - The backend provides various API endpoints for interacting with the story creation process, including story generation, image creation, script alignment, audio processing, and video assembly.

--- a/backend/src/agents/image_generation_agent.py
+++ b/backend/src/agents/image_generation_agent.py
@@ -4,6 +4,9 @@ from typing import Optional
 import openai
 import requests
 
+from ..config import Config
+from ..defaults import DEFAULT_IMAGE_PATH
+
 
 class ImageGenerationAgent:
     def __init__(self, openai_api_key: Optional[str] = None):
@@ -15,12 +18,19 @@ class ImageGenerationAgent:
 
     def generate_image(self, prompt: str) -> str:
         """Generate an image based on the provided prompt using DALL·E."""
+        if Config.DEMO_MODE:
+            # In demo mode return a placeholder image instead of calling OpenAI.
+            return DEFAULT_IMAGE_PATH
+
         self._set_api_key()
         response = openai.Image.create(prompt=prompt, n=1)
         return response["data"][0]["url"]
 
     def modify_image(self, image_path: str, new_prompt: str) -> str:
         """Modify an existing image based on a new prompt."""
+        if Config.DEMO_MODE:
+            return DEFAULT_IMAGE_PATH
+
         self._set_api_key()
         with open(image_path, "rb") as img:
             response = openai.Image.create_edit(image=img, prompt=new_prompt, n=1)
@@ -28,6 +38,9 @@ class ImageGenerationAgent:
 
     def regenerate_image(self, image_path: str) -> str:
         """Regenerate an image based on its ID."""
+        if Config.DEMO_MODE:
+            return DEFAULT_IMAGE_PATH
+
         self._set_api_key()
         with open(image_path, "rb") as img:
             response = openai.Image.create_variation(image=img, n=1)

--- a/backend/src/app.py
+++ b/backend/src/app.py
@@ -1,7 +1,19 @@
 from fastapi import FastAPI
+from fastapi.staticfiles import StaticFiles
+from pathlib import Path
+
 from .routes import image_routes, story_routes, script_routes, tts_routes, video_routes
+from .config import Config
 
 app = FastAPI()
+
+if Config.DEMO_MODE:
+    # In demo mode we optionally serve a built frontend from the `frontend_dist`
+    # directory located at the repository root. This allows running the full
+    # application locally without external dependencies.
+    frontend_dir = Path(__file__).resolve().parent.parent / "frontend_dist"
+    if frontend_dir.exists():
+        app.mount("/", StaticFiles(directory=frontend_dir, html=True), name="frontend")
 
 app.include_router(story_routes.router, prefix="/stories", tags=["stories"])
 app.include_router(script_routes.router, prefix="/scripts", tags=["scripts"])

--- a/backend/src/audio_processing/stt.py
+++ b/backend/src/audio_processing/stt.py
@@ -1,3 +1,7 @@
+from ..config import Config
+from ..defaults import DEFAULT_TRANSCRIPTION
+
+
 class STTProcessor:
     def __init__(self, model):
         self.model = model
@@ -18,6 +22,9 @@ class STTProcessor:
 
         if not os.path.isfile(audio_file):
             raise FileNotFoundError(f"Audio file '{audio_file}' not found")
+
+        if Config.DEMO_MODE:
+            return DEFAULT_TRANSCRIPTION
 
         try:
             with open(audio_file, "rb") as f:

--- a/backend/src/config.py
+++ b/backend/src/config.py
@@ -8,6 +8,11 @@ class Config:
     DEBUG = os.getenv("DEBUG", "False") == "True"
     SECRET_KEY = os.getenv("SECRET_KEY", "your_secret_key_here")
 
+    # Demo mode bypasses calls to external services like OpenAI and returns
+    # predefined data instead. Enable by setting `DEMO_MODE=true` in the
+    # environment when running tests or local demos.
+    DEMO_MODE = os.getenv("DEMO_MODE", "False").lower() == "true"
+
     # OpenAI API configuration
     OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", "your_openai_api_key_here")
 

--- a/backend/src/defaults.py
+++ b/backend/src/defaults.py
@@ -1,0 +1,13 @@
+"""Default data used when DEMO_MODE is enabled."""
+
+from pathlib import Path
+
+# Path to a placeholder image served when image generation is bypassed.
+DEFAULT_IMAGE_PATH = str(
+    Path(__file__).resolve().parent.parent / "static" / "default.png"
+)
+
+# Text returned by the speech-to-text processor in demo mode.
+DEFAULT_TRANSCRIPTION = "This is a sample transcription."
+
+# Additional defaults can be added here as needed.

--- a/backend/static/default.png
+++ b/backend/static/default.png
@@ -1,0 +1,1 @@
+sample image

--- a/frontend_dist/index.html
+++ b/frontend_dist/index.html
@@ -1,0 +1,1 @@
+<html><body>Demo</body></html>

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,23 @@
+import os
+from fastapi.testclient import TestClient
+
+from backend.src.app import app
+
+
+def test_frontend_served(tmp_path, monkeypatch):
+    # Enable demo mode so the frontend is mounted
+    monkeypatch.setenv("DEMO_MODE", "true")
+    client = TestClient(app)
+
+    response = client.get("/")
+    assert response.status_code == 200
+    assert "Demo" in response.text
+
+
+def test_generate_image_demo(monkeypatch):
+    monkeypatch.setenv("DEMO_MODE", "true")
+    client = TestClient(app)
+
+    response = client.post("/images/generate-image", json={"prompt": "cat"})
+    assert response.status_code == 200
+    assert response.json()["image_url"].endswith("default.png")


### PR DESCRIPTION
## Summary
- add DEMO_MODE config and defaults for offline testing
- provide small placeholder image and frontend stub
- mount built frontend in demo mode
- describe integration workflow in docs
- add integration tests exercising demo mode
- replace binary default image with text placeholder

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `black --check backend/src`
- `cd frontend && npx tsc --noEmit && npx prettier -c src && cd ..` *(TypeScript errors)*
- `pytest -q` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685412e3326c8325a83efab49f40250e