### PR TITLE
Update backend testing setup

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -37,6 +37,7 @@ shortvideo-story-creator-backend
    pip install -r requirements.txt
    # Install extra tools for development and testing
    pip install -r requirements-dev.txt
+   # requirements-dev.txt installs pytest, pytest-asyncio and black
    ```
 
 3. **Configuration:**
@@ -47,6 +48,17 @@ shortvideo-story-creator-backend
    ```bash
    python src/app.py
    ```
+
+## Running Tests
+
+Install the development requirements first:
+```bash
+pip install -r requirements-dev.txt
+```
+Then run the tests with `pytest`:
+```bash
+pytest
+```
 
 ### Demo mode
 


### PR DESCRIPTION
## Summary
- document that `requirements-dev.txt` installs pytest, pytest-asyncio and black
- add section on running tests in backend README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `black --check backend/src`
- `cd frontend && npx tsc --noEmit && npx prettier -c src && cd ..` *(fails: Cannot find module 'react' types)*


------
https://chatgpt.com/codex/tasks/task_e_68541bb230b88325a691ffce185903c3