### PR TITLE
Add frontend build to Docker

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,19 +1,15 @@
+FROM node:20 AS frontend-builder
+WORKDIR /frontend
+COPY frontend/package*.json ./
+RUN npm install
+COPY frontend/ ./
+RUN npm run build
+
 FROM python:3.12-slim
-
-# Set the working directory
 WORKDIR /app
-
-# Copy the requirements file
 COPY requirements.txt .
-
-# Install the dependencies
 RUN pip install --no-cache-dir -r requirements.txt
-
-# Copy the source code into the container
 COPY src/ ./src/
-
-# Expose the port the app runs on
+COPY --from=frontend-builder /frontend/dist /app/frontend_dist
 EXPOSE 8000
-
-# Command to run the application
 CMD ["uvicorn", "src.app:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/src/app.py
+++ b/backend/src/app.py
@@ -7,10 +7,10 @@ from .config import Config
 
 app = FastAPI()
 
-if Config.DEMO_MODE:
-    # In demo mode we optionally serve a built frontend from the `frontend_dist`
-    # directory located at the repository root. This allows running the full
-    # application locally without external dependencies.
+# Optionally mount a prebuilt frontend if present. This is controlled by the
+# SERVE_FRONTEND flag rather than DEMO_MODE so the container can always serve
+# the React bundle when it is copied in during the Docker build.
+if Config.SERVE_FRONTEND:
     frontend_dir = Path(__file__).resolve().parent.parent / "frontend_dist"
     if frontend_dir.exists():
         app.mount("/", StaticFiles(directory=frontend_dir, html=True), name="frontend")

--- a/backend/src/config.py
+++ b/backend/src/config.py
@@ -13,6 +13,10 @@ class Config:
     # environment when running tests or local demos.
     DEMO_MODE = os.getenv("DEMO_MODE", "False").lower() == "true"
 
+    # Serve a prebuilt frontend with the backend. Defaults to True so containers
+    # include the static assets built in the Docker image.
+    SERVE_FRONTEND = os.getenv("SERVE_FRONTEND", "True").lower() == "true"
+
     # OpenAI API configuration
     OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", "your_openai_api_key_here")
 


### PR DESCRIPTION
## Summary
- build frontend in a Node stage
- copy React `dist` into the final Python image
- serve frontend via new `SERVE_FRONTEND` flag

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `black --check backend/src`
- `cd frontend && npm install && npx tsc --noEmit && npx prettier -c src && cd ..`


------
https://chatgpt.com/codex/tasks/task_e_6854255350888325bd110d837b2557f1