### PR TITLE
Add demo mode output for script alignment agent

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -63,8 +63,8 @@ pytest
 ### Demo mode
 
 Set the environment variable `DEMO_MODE=true` to bypass external OpenAI calls.
-Default images and transcription text will be returned instead, making it easy
-to test the full stack offline.
+Default images, transcription text, and an example aligned script will be
+returned instead, making it easy to test the full stack offline.
 
 ## Usage Guidelines
 

--- a/backend/src/agents/script_alignment_agent.py
+++ b/backend/src/agents/script_alignment_agent.py
@@ -1,9 +1,25 @@
+from ..config import Config
+from ..defaults import DEFAULT_IMAGE_PATH, DEFAULT_SCRIPT_LINES
+
+
 class ScriptAlignmentAgent:
     def __init__(self) -> None:
         self.script: list[str] = []
 
     def align_script_with_images(self, images, script):
         """Align a list of script dialogue lines with the given images."""
+        if Config.DEMO_MODE:
+            demo_images = images or [DEFAULT_IMAGE_PATH] * len(DEFAULT_SCRIPT_LINES)
+            return [
+                {
+                    "image": (
+                        demo_images[i] if i < len(demo_images) else DEFAULT_IMAGE_PATH
+                    ),
+                    "dialogue": line,
+                }
+                for i, line in enumerate(DEFAULT_SCRIPT_LINES)
+            ]
+
         aligned_script = []
         for i, image in enumerate(images):
             aligned_script.append(

--- a/backend/src/defaults.py
+++ b/backend/src/defaults.py
@@ -10,4 +10,11 @@ DEFAULT_IMAGE_PATH = str(
 # Text returned by the speech-to-text processor in demo mode.
 DEFAULT_TRANSCRIPTION = "This is a sample transcription."
 
+# Default script lines returned by the script alignment agent in demo mode.
+DEFAULT_SCRIPT_LINES = [
+    "This is a demo script line one.",
+    "Here is demo line two matching an image.",
+    "Finally demo line three completes the sample.",
+]
+
 # Additional defaults can be added here as needed.

--- a/tests/test_script_alignment_agent.py
+++ b/tests/test_script_alignment_agent.py
@@ -1,5 +1,7 @@
 import pytest
 from backend.src.agents.script_alignment_agent import ScriptAlignmentAgent
+from backend.src.defaults import DEFAULT_SCRIPT_LINES, DEFAULT_IMAGE_PATH
+from backend.src.config import Config
 
 
 @pytest.fixture
@@ -39,3 +41,11 @@ def test_generate_script_summary_includes_all_entries(agent):
     summary = agent.generate_script_summary(aligned)
     assert "Image: img1.png, Dialogue: Hello" in summary
     assert "Image: img2.png, Dialogue: World" in summary
+
+
+def test_align_script_with_images_demo_mode(monkeypatch, agent):
+    monkeypatch.setattr(Config, "DEMO_MODE", True)
+    result = agent.align_script_with_images(["img.png"], ["ignored"])
+    assert len(result) == len(DEFAULT_SCRIPT_LINES)
+    assert result[0]["dialogue"] == DEFAULT_SCRIPT_LINES[0]
+    assert result[1]["image"].endswith("default.png")


### PR DESCRIPTION
## Summary
- provide demo script lines in `defaults`
- return placeholder alignment when `DEMO_MODE` is on
- test demo alignment mode
- document demo script behavior

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `black --check backend/src`
- `cd frontend && npx tsc --noEmit && npx prettier -c src && cd ..`
- `pytest -q` *(fails: ModuleNotFoundError: httpx, ffmpeg, openai, moviepy)*

------
https://chatgpt.com/codex/tasks/task_e_68545e004c80832590cc49983d72972c