### PR TITLE
Add demo mode to TTS agent

### DIFF
--- a/backend/src/agents/tts_agent.py
+++ b/backend/src/agents/tts_agent.py
@@ -5,6 +5,8 @@ import tempfile
 import ffmpeg
 
 from ..audio_processing.tts import TTSProcessor
+from ..config import Config
+from ..defaults import DEFAULT_TTS_AUDIO
 
 
 class TTSAgent:
@@ -25,6 +27,8 @@ class TTSAgent:
         """Generate audio for the given text using a specific voice style."""
 
         self.select_voice_style(voice_style)
+        if Config.DEMO_MODE:
+            return f"{DEFAULT_TTS_AUDIO} ({voice_style}): {text}"
         return self.tts_processor.generate_audio(text)
 
     def generate_audio_clip(self, text: str) -> Any:  # Backwards compatibility

--- a/backend/src/defaults.py
+++ b/backend/src/defaults.py
@@ -10,4 +10,7 @@ DEFAULT_IMAGE_PATH = str(
 # Text returned by the speech-to-text processor in demo mode.
 DEFAULT_TRANSCRIPTION = "This is a sample transcription."
 
+# Text returned by the text-to-speech agent when audio generation is bypassed.
+DEFAULT_TTS_AUDIO = "This is a demo audio clip."
+
 # Additional defaults can be added here as needed.

--- a/tests/test_tts_agent.py
+++ b/tests/test_tts_agent.py
@@ -3,6 +3,7 @@ import wave
 import os
 
 from backend.src.agents.tts_agent import TTSAgent
+from backend.src.agents import tts_agent
 from backend.src.audio_processing.tts import TTSProcessor
 
 
@@ -55,3 +56,15 @@ def test_generate_audio_clip_uses_processor():
 
     processor.generate_audio.assert_called_once_with("hi")
     assert clip == "result"
+
+
+def test_generate_audio_in_demo_mode(monkeypatch):
+    processor = MagicMock(spec=TTSProcessor)
+    agent = TTSAgent(processor)
+    agent._available_voices = ["default"]
+    monkeypatch.setattr(tts_agent.Config, "DEMO_MODE", True)
+
+    result = agent.generate_audio("demo", "default")
+
+    assert "demo audio clip" in result
+    processor.generate_audio.assert_not_called()


### PR DESCRIPTION
## Summary
- return a text placeholder when DEMO_MODE is enabled for TTS
- document demo audio text constant
- test TTS agent demo mode behavior

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `black --check backend/src`
- `cd frontend && npx tsc --noEmit && npx prettier -c src && cd ..` *(fails: missing React types)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68545e0d373c8325a8d633365d1f8d89