### PR TITLE
Add demo mode for video assembly

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ An interactive, agentic web app powered by OpenAI to create AI-driven storyboard
 
 To experiment with the complete stack locally, you can run the backend in
 `DEMO_MODE`. This bypasses all OpenAI endpoints and serves a small frontend build
-mounted at the FastAPI root path.
+mounted at the FastAPI root path. In this mode, video assembly outputs a text
+description instead of a real video.
 
 Steps:
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -64,7 +64,8 @@ pytest
 
 Set the environment variable `DEMO_MODE=true` to bypass external OpenAI calls.
 Default images and transcription text will be returned instead, making it easy
-to test the full stack offline.
+to test the full stack offline. Video assembly writes a text file describing
+the provided images and audio rather than producing an actual video.
 
 ## Usage Guidelines
 

--- a/backend/src/agents/video_assembly_agent.py
+++ b/backend/src/agents/video_assembly_agent.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 from moviepy.audio.io.AudioFileClip import AudioFileClip
 from moviepy.video.VideoClip import ImageClip
 from moviepy.video.compositing.CompositeVideoClip import concatenate_videoclips
+from itertools import zip_longest
+
+from ..config import Config
 
 
 class VideoAssemblyAgent:
@@ -12,6 +15,13 @@ class VideoAssemblyAgent:
     def assemble_video(
         self, images: list[str], audio_clips: list[str], output_path: str
     ) -> str:
+        if Config.DEMO_MODE:
+            with open(output_path, "w", encoding="utf-8") as f:
+                for idx, (img, aud) in enumerate(zip_longest(images, audio_clips)):
+                    line = f"frame{idx}: image={img or ''}, audio={aud or ''}\n"
+                    f.write(line)
+            return output_path
+
         clips = []
         for img_path, audio_path in zip(images, audio_clips):
             audio = AudioFileClip(audio_path)

--- a/tests/test_video_assembly_agent.py
+++ b/tests/test_video_assembly_agent.py
@@ -19,7 +19,8 @@ def create_audio(path: Path, duration: int = 500) -> None:
         wf.writeframes(b"\x00\x00" * nframes)
 
 
-def test_assemble_video_creates_file(tmp_path: Path) -> None:
+def test_assemble_video_creates_file(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("DEMO_MODE", "true")
     imgs = []
     auds = []
     for i in range(2):
@@ -29,10 +30,13 @@ def test_assemble_video_creates_file(tmp_path: Path) -> None:
         create_audio(aud)
         imgs.append(str(img))
         auds.append(str(aud))
-    output = tmp_path / "output.mp4"
+    output = tmp_path / "output.txt"
     agent = VideoAssemblyAgent()
     agent.assemble_video(imgs, auds, str(output))
     assert output.exists()
+    content = output.read_text().strip().splitlines()
+    assert len(content) == 2
+    assert "image=" in content[0]
 
 
 def test_preview_and_upload_return_dict() -> None:


### PR DESCRIPTION
## Summary
- implement demo mode in `VideoAssemblyAgent`
- document demo behavior in README files
- update tests to check demo mode output

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `black --check backend/src`
- `npx tsc --noEmit` *(fails: tsc not installed)*
- `npx prettier -c src`
- `pytest -q` *(fails: missing httpx, ffmpeg, openai, moviepy)*

------
https://chatgpt.com/codex/tasks/task_e_68545e1f125883258e507c649cea2ec8