### PR TITLE
Add demo mode to story agent

### DIFF
--- a/backend/src/agents/story_agent.py
+++ b/backend/src/agents/story_agent.py
@@ -3,6 +3,8 @@ from dataclasses import dataclass
 from typing import Literal, List, Optional
 
 from agents import Agent, ItemHelpers, Runner, TResponseInputItem, trace
+from ..config import Config
+from ..defaults import DEFAULT_STORY_OUTLINE
 
 
 @dataclass
@@ -39,6 +41,8 @@ class StoryAgent:
         """
         Generate a story outline based on the provided story idea.
         """
+        if Config.DEMO_MODE:
+            return DEFAULT_STORY_OUTLINE
         if max_turns < 1:
             raise ValueError("Max turns must be greater than 0.")
         if max_turns > 5:
@@ -91,6 +95,8 @@ class StoryAgent:
     async def refine_outline(self, outline: str, feedback: str) -> str:
         # Logic to refine the existing story outline based on user feedback
         # todo - convert feedback into using a feedback tool to ensure it is in the correct format
+        if Config.DEMO_MODE:
+            return DEFAULT_STORY_OUTLINE
         input_items: List[TResponseInputItem] = [
             {"content": outline, "role": "assistant"},
             {"content": f"Feedback: {feedback}", "role": "user"},

--- a/backend/src/defaults.py
+++ b/backend/src/defaults.py
@@ -10,4 +10,7 @@ DEFAULT_IMAGE_PATH = str(
 # Text returned by the speech-to-text processor in demo mode.
 DEFAULT_TRANSCRIPTION = "This is a sample transcription."
 
+# Story outline returned by the story agent when demo mode is enabled.
+DEFAULT_STORY_OUTLINE = "This is a sample story outline."
+
 # Additional defaults can be added here as needed.

--- a/tests/test_story_agent.py
+++ b/tests/test_story_agent.py
@@ -58,3 +58,16 @@ async def test_refine_outline_returns_new(monkeypatch):
 
     result = await agent.refine_outline("old", "feedback")
     assert result == "new outline"
+
+
+@pytest.mark.asyncio
+async def test_generate_outline_demo_mode(monkeypatch):
+    monkeypatch.setenv("DEMO_MODE", "true")
+    import importlib
+
+    import backend.src.agents.story_agent as sa
+
+    importlib.reload(sa)
+    agent = sa.StoryAgent()
+    outline = await agent.generate_outline("idea")
+    assert outline == sa.DEFAULT_STORY_OUTLINE


### PR DESCRIPTION
## Summary
- support demo mode in `StoryAgent`
- return a default outline for easier testing
- document default outline constant
- test story agent demo behavior

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `black --check backend/src`
- `npx prettier -c src`
- `npx tsc --noEmit` *(fails: Cannot find module 'react')*
- `pytest -q` *(fails: ModuleNotFoundError: httpx, ffmpeg, openai, moviepy)*

------
https://chatgpt.com/codex/tasks/task_e_68545dd6a03883259dc13650f6edeb5b