### PR TITLE
Switch to tabbed UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # TaleCraft
-An interactive, agentic web app powered by OpenAI to create AI-driven storyboards and short videos, enabling easy, user-driven storytelling.
+
+An interactive, agentic web app powered by OpenAI to create AI-driven storyboards and short videos, enabling easy, user-driven storytelling. The frontend now uses a tabbed layout so you can jump between stages of the workflow without losing context.
 
 ## Integration Testing
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The ShortVideo Story Creator App is an interactive, browser-based application powered by OpenAI that assists users in generating engaging stories for short videos. The app allows for full interactivity at each stage of the story creation process, from initial idea input to final video production.
+The ShortVideo Story Creator App is an interactive, browser-based application powered by OpenAI that assists users in generating engaging stories for short videos. The app allows for full interactivity at each stage of the story creation process, from initial idea input to final video production. A tab bar at the top of the page guides you through the workflow, starting with an overview and continuing through story creation, image generation, audio, and video assembly.
 
 ## Features
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,36 +1,17 @@
 import React from "react";
-import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import Header from "./components/Header";
 import Footer from "./components/Footer";
-import Home from "./pages/Home";
-import Outline from "./pages/Outline";
-import Storyboard from "./components/Storyboard";
-import ImageGeneration from "./components/ImageGeneration";
-import ScriptAlignment from "./components/ScriptAlignment";
-import TextToSpeech from "./components/TextToSpeech";
-import VideoAssembly from "./components/VideoAssembly";
-import FinalProduction from "./components/FinalProduction";
+import TabbedWorkflow from "./components/TabbedWorkflow";
 
 const App: React.FC = () => {
   return (
-    <Router>
-      <div className="flex flex-col min-h-screen">
-        <Header />
-        <main className="flex-grow">
-          <Routes>
-            <Route path="/" element={<Home />} />
-            <Route path="/outline" element={<Outline />} />
-            <Route path="/storyboard" element={<Storyboard />} />
-            <Route path="/image-generation" element={<ImageGeneration />} />
-            <Route path="/script-alignment" element={<ScriptAlignment />} />
-            <Route path="/text-to-speech" element={<TextToSpeech />} />
-            <Route path="/video-assembly" element={<VideoAssembly />} />
-            <Route path="/final-production" element={<FinalProduction />} />
-          </Routes>
-        </main>
-        <Footer />
-      </div>
-    </Router>
+    <div className="flex flex-col min-h-screen">
+      <Header />
+      <main className="flex-grow">
+        <TabbedWorkflow />
+      </main>
+      <Footer />
+    </div>
   );
 };
 

--- a/frontend/src/components/Overview.tsx
+++ b/frontend/src/components/Overview.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+
+const Overview: React.FC = () => {
+  return (
+    <div className="p-4">
+      <h2 className="text-2xl font-bold mb-4">Workflow Overview</h2>
+      <p className="mb-2">
+        This app guides you through the entire short video creation process. Use
+        the tabs above to move between stages. Start with the Story tab to craft
+        your outline, then generate images and audio before assembling the final
+        video.
+      </p>
+    </div>
+  );
+};
+
+export default Overview;

--- a/frontend/src/components/TabbedWorkflow.tsx
+++ b/frontend/src/components/TabbedWorkflow.tsx
@@ -1,0 +1,62 @@
+import React, { useState } from "react";
+import Overview from "./Overview";
+import StoryInput from "./StoryInput";
+import StoryOutline from "./StoryOutline";
+import Storyboard from "./Storyboard";
+import ImageGeneration from "./ImageGeneration";
+import ScriptAlignment from "./ScriptAlignment";
+import TextToSpeech from "./TextToSpeech";
+import VideoAssembly from "./VideoAssembly";
+import FinalProduction from "./FinalProduction";
+
+const TabbedWorkflow: React.FC = () => {
+  const tabs = [
+    { id: "overview", label: "Overview", content: <Overview /> },
+    {
+      id: "story",
+      label: "Story",
+      content: (
+        <div>
+          <StoryInput />
+          <StoryOutline />
+        </div>
+      ),
+    },
+    { id: "storyboard", label: "Storyboard", content: <Storyboard /> },
+    { id: "image", label: "Images", content: <ImageGeneration /> },
+    { id: "script", label: "Script", content: <ScriptAlignment /> },
+    { id: "audio", label: "Audio", content: <TextToSpeech /> },
+    { id: "video", label: "Video", content: <VideoAssembly /> },
+    { id: "final", label: "Final", content: <FinalProduction /> },
+  ];
+
+  const [activeTab, setActiveTab] = useState(tabs[0].id);
+
+  return (
+    <div className="p-4">
+      <div className="border-b mb-4">
+        <ul className="flex flex-wrap -mb-px">
+          {tabs.map((tab) => (
+            <li key={tab.id} className="mr-2">
+              <button
+                className={`inline-block rounded-t px-4 py-2 border-b-2 ${activeTab === tab.id ? "border-blue-500 text-blue-600" : "border-transparent hover:text-blue-600 hover:border-gray-300"}`}
+                onClick={() => setActiveTab(tab.id)}
+              >
+                {tab.label}
+              </button>
+            </li>
+          ))}
+        </ul>
+      </div>
+      <div>
+        {tabs.map((tab) => (
+          <div key={tab.id} className={activeTab === tab.id ? "" : "hidden"}>
+            {tab.content}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default TabbedWorkflow;


### PR DESCRIPTION
## Summary
- introduce a TabbedWorkflow component with stages of the story flow
- show the tabbed workflow in `App`
- add an overview tab explaining the flow
- note the tabbed navigation in documentation

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `black --check backend/src`
- `npx tsc --noEmit` *(fails: cannot find module 'react')*
- `npx prettier -c src`

------
https://chatgpt.com/codex/tasks/task_e_68582cb3195c8325b98c6e1c42236e67