### PR TITLE
Implement disabled tab styling

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -43,6 +43,13 @@ The ShortVideo Story Creator App is an interactive, browser-based application po
 4. Open your browser and navigate to `http://localhost:3000` to view the application.
 5. Build a production bundle with `npm run build`.
 
+### Demo Mode
+
+Set `VITE_DEMO_MODE=true` when running the development server or building the
+frontend to enable demo mode. In this mode all workflow tabs are accessible and
+are highlighted in light red to indicate they are not yet unlocked in the normal
+flow.
+
 ## License
 
 This project is licensed under the MIT License. See the LICENSE file for details.

--- a/frontend/src/components/TabbedWorkflow.tsx
+++ b/frontend/src/components/TabbedWorkflow.tsx
@@ -31,21 +31,43 @@ const TabbedWorkflow: React.FC = () => {
   ];
 
   const [activeTab, setActiveTab] = useState(tabs[0].id);
+  const demoMode = import.meta.env.VITE_DEMO_MODE === "true";
+
+  const initialEnabled = new Set(["overview", "story"]);
 
   return (
     <div className="p-4">
       <div className="border-b mb-4">
         <ul className="flex flex-wrap -mb-px">
-          {tabs.map((tab) => (
-            <li key={tab.id} className="mr-2">
-              <button
-                className={`inline-block rounded-t px-4 py-2 border-b-2 ${activeTab === tab.id ? "border-blue-500 text-blue-600" : "border-transparent hover:text-blue-600 hover:border-gray-300"}`}
-                onClick={() => setActiveTab(tab.id)}
-              >
-                {tab.label}
-              </button>
-            </li>
-          ))}
+          {tabs.map((tab) => {
+            const isInitial = initialEnabled.has(tab.id);
+            const disabled = !demoMode && !isInitial;
+            const demoDisabled = demoMode && !isInitial;
+
+            let classes = "inline-block rounded-t px-4 py-2 border-b-2 ";
+            if (activeTab === tab.id) {
+              classes += "border-blue-500 text-blue-600";
+            } else if (disabled) {
+              classes += "border-transparent text-gray-400 cursor-not-allowed";
+            } else if (demoDisabled) {
+              classes += "border-red-300 text-red-400 hover:text-red-600";
+            } else {
+              classes +=
+                "border-transparent hover:text-blue-600 hover:border-gray-300";
+            }
+
+            return (
+              <li key={tab.id} className="mr-2">
+                <button
+                  className={classes}
+                  disabled={disabled}
+                  onClick={() => !disabled && setActiveTab(tab.id)}
+                >
+                  {tab.label}
+                </button>
+              </li>
+            );
+          })}
         </ul>
       </div>
       <div>

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,12 +1,13 @@
 {
   "compilerOptions": {
     "target": "es6",
-    "module": "commonjs",
+    "module": "esnext",
     "jsx": "react",
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
+    "types": ["vite/client"],
     "baseUrl": "src",
     "paths": {
       "@components/*": ["components/*"],


### PR DESCRIPTION
## Summary
- disable workflow tabs until unlocked
- document how to enable demo mode in the frontend
- update TypeScript config for Vite environment

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `black --check backend/src`
- `npx tsc --noEmit`
- `npx prettier -c src`

------
https://chatgpt.com/codex/tasks/task_e_68583a96ddfc8325850abe45e5d40a83