### PR TITLE
Use demo endpoint for API in demo mode

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -48,7 +48,8 @@ The ShortVideo Story Creator App is an interactive, browser-based application po
 Set `VITE_DEMO_MODE=true` when running the development server or building the
 frontend to enable demo mode. In this mode all workflow tabs are accessible and
 are highlighted in light red to indicate they are not yet unlocked in the normal
-flow.
+flow. The backend API endpoint can be overridden with the `VITE_DEMO_ENDPOINT`
+variable, defaulting to `http://localhost:8000`.
 
 ## License
 

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,0 +1,15 @@
+export const DEMO_ENDPOINT = "http://localhost:8000";
+
+const demoMode = import.meta.env.VITE_DEMO_MODE === "true";
+
+export const API_BASE = demoMode
+  ? import.meta.env.VITE_DEMO_ENDPOINT || DEMO_ENDPOINT
+  : "";
+
+export function apiFetch(
+  path: string,
+  options?: RequestInit,
+): Promise<Response> {
+  const url = `${API_BASE}${path}`;
+  return fetch(url, options);
+}

--- a/frontend/src/components/ImageGeneration.tsx
+++ b/frontend/src/components/ImageGeneration.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { apiFetch } from "../api";
 
 const ImageGeneration: React.FC = () => {
   const [prompt, setPrompt] = useState("");
@@ -9,7 +10,7 @@ const ImageGeneration: React.FC = () => {
     setLoading(true);
     try {
       // Call the DALL·E API to generate images based on the prompt
-      const response = await fetch("/images/generate-image", {
+      const response = await apiFetch("/images/generate-image", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",

--- a/frontend/src/components/StoryInput.tsx
+++ b/frontend/src/components/StoryInput.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { apiFetch } from "../api";
 
 const StoryInput: React.FC = () => {
   const [storyIdea, setStoryIdea] = useState<string>("");
@@ -11,7 +12,7 @@ const StoryInput: React.FC = () => {
   const handleSubmit = async (event: React.FormEvent) => {
     event.preventDefault();
     try {
-      const response = await fetch("/stories/generate", {
+      const response = await apiFetch("/stories/generate", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",

--- a/frontend/src/components/StoryOutline.tsx
+++ b/frontend/src/components/StoryOutline.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { apiFetch } from "../api";
 
 const StoryOutline: React.FC = () => {
   const [storyOutline, setStoryOutline] = useState<string>("");
@@ -10,7 +11,7 @@ const StoryOutline: React.FC = () => {
 
   const generateOutline = async () => {
     try {
-      const response = await fetch("/stories/refine", {
+      const response = await apiFetch("/stories/refine", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",

--- a/frontend/src/components/TextToSpeech.tsx
+++ b/frontend/src/components/TextToSpeech.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { apiFetch } from "../api";
 
 const TextToSpeech: React.FC = () => {
   const [voice, setVoice] = useState<string>("default");
@@ -16,7 +17,7 @@ const TextToSpeech: React.FC = () => {
   const generateAudio = async () => {
     // Placeholder for audio generation logic
     // This should call the TTS API and set the audio URL
-    const response = await fetch("/tts/generate_audio", {
+    const response = await apiFetch("/tts/generate_audio", {
       method: "POST",
       headers: {
         "Content-Type": "application/json",


### PR DESCRIPTION
## Summary
- create `apiFetch` helper for automatic API base handling
- call `apiFetch` in components
- document `VITE_DEMO_ENDPOINT` usage

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `black --check backend/src`
- `cd frontend && npx tsc --noEmit && npx prettier -c src && cd ..`


------
https://chatgpt.com/codex/tasks/task_e_685845d6d4588325b8d328fe7da64220